### PR TITLE
Use `extends` and templating features

### DIFF
--- a/base.yml
+++ b/base.yml
@@ -1,0 +1,47 @@
+version: 1
+project:
+  license: CC-BY-4.0
+  open_access: true
+  venue: Nucleus
+  subject: Developer Note
+  github: https://github.com/bnext-bio/nucleus-developer-notes
+  references:
+    devnotes: https://devnotes.bnext.bio
+  abbreviations:
+    MyST: Markedly Structured Text
+    CDK: cell development kit
+  keywords:
+    - Synthetic Biology
+    - Nucleus
+  plugins:
+    - lorem.mjs
+  jupyter: true
+  exports:
+    - format: meca
+    # - format: typst
+    #   template: https://github.com/curvenote-templates/bnext.git
+    #   article: main.md
+    #   output: bnext-template.pdf
+    #   id: article
+  requirements:
+    - environment.yml
+  resources:
+    - src/**/*
+    - figures/**/*
+    - experiments/**/*
+  downloads:
+    # - id: article
+    #   title: Download Article PDF
+    - file: experiments/experimental-01/00-general/MTHFS-labnotebook.pdf
+      title: Lab Notebook Entry
+  #
+  # Are there standard reference sources that should be made available to the
+  # author within the template to make citing easy? if so add a .bib file and
+  # list it here.
+  #
+  # bibliography:
+  #   - references.bib
+  #   - https://devnotes.bnext.bio/references.bib
+site:
+  template: article-theme
+  nav: []

--- a/curvenote.yml
+++ b/curvenote.yml
@@ -1,12 +1,15 @@
 version: 1
+extends: base.yml
 project:
   # doi: 10.63765/djnv7772
-  # Update this to match `nucleus-devnote-core-<folder>` the folder should be `???`
-  id: nucleus-devnote-core-00_myst_template
+  #
+  # id: the-curvenote-init-process-will-create-a-random-id
+  #
   # Ensure your title is the same as in your `main.md`
-  title: "MTHFS - an Unexpected Enzyme in PURE" 
-  subtitle: "[summarize my devnote in one sentence]" 
-  description: "[this appears as description for social media preview, recommend using subtitle]" 
+  title: "MTHFS - an Unexpected Enzyme in PURE"
+  subtitle: "[summarize my devnote in one sentence]"
+  description: "[this appears as description for social media preview, recommend using subtitle]"
+  #
   # Authors should have affiliations, emails and ORCIDs if available
   authors:
     - name: Yemo Ku
@@ -19,20 +22,20 @@ project:
           postal_code: 94107
           country: USA
       corresponding: true
-  keywords:
-    - Cytosol
-    - Module
-  # Add the abbreviations that you use in your paper here
+  #
+  # Add keywords for your devnote here.
+  # keywords:
+  #   - Cytosol
+  #   - Module
+  #
+  # Common abbreviations are included (see base.yml), the list of abbreviations can be extended here.
   # abbreviations:
-  #   MyST: Markedly Structured Text
-  #   CDK: cell development kit
-  # Add specs here for any additional content you want to cross reference
-  references:
-    devnotes: https://devnotes.bnext.bio
+  #   THING: Something specific to this devnote
+  #
   # Set an initial publisation date for the note
   date: 2025-07-10
   # Reference a specific thumbnail if you are not happy with the automatically selected one
-  #thumbnail: thumbnail.png
+  # thumbnail: thumbnail.png
   # A create a banner image for your publication, use this is a placeholder as a guide (webp or png)
   banner: banner.webp
   # Add any supporting files to the toc, but ensure that your main manuscript is first is the list
@@ -40,38 +43,36 @@ project:
     - file: main.md
     - file: experiments/experimental-01/20250220-analysis.ipynb
   # The rest of the information shouldn't be modified
-  github: https://github.com/bnext-bio/nucleus-developer-notes
-  license: CC-BY-4.0
-  open_access: true
-  venue: Nucleus
-  subject: Developer Note
-  plugins:
-    - lorem.mjs
+  #
+  # Standard plugins are included (see base.yml), the list of plugins can be extended here.
+  # plugins:
+  #   - my-plugin.mjs
   # compute configuration, see: https://curvenote.com/docs/publish/live-compute#configuration-via-frontmatter
-  jupyter: true
-  exports:
-    - format: meca
-    # - format: typst
-    #   template: https://github.com/curvenote-templates/bnext.git
-    #   article: main.md
-    #   output: bnext-template.pdf
-    #   id: article
-  requirements:
-    - environment.yml
-  resources:
-    - general/**/*
-    - src/**/*
-    - experimental/**/*
-    - figures/**/*
+  #
+  # Requirements & Resources for executing the devnote
+  #
+  # By default, the environment.yml file is included (see base.yml), the list of requirements sources
+  # can be extended here.
+  # requirements:
+  #   - another-requirements-file.yml
+  #
+  # By default, the src/, figures/ and experiments/ directories are included (see base.yml), the list
+  # of resources can be extended here. Resources are files that should be packaged with the devnote
+  # that are not otherwise included in the article itself. e.g. data files, images, etc. but usually
+  # needed to execute the devnote.
+  # resources:
+  #   - data/**/*
+  #
+  # Downloads are files that should be packaged with the devnote for download by the reader.
   downloads:
-    # - id: article
-    #   title: Download Article PDF
     - file: experiments/experimental-01/00-general/MTHFS-labnotebook.pdf
       title: Lab Notebook Entry
+  #
+  # Funding information can be added here.
   # funding:
   #   - id: G-0000-00000
   #     source:
   #       - Alfred P. Sloan Foundation
-site:
-  template: article-theme
-  nav: []
+  #
+  # For additional project-level configuration, see https://docs.curvenote.com/publish/metadata-essentials
+  #

--- a/template.yml
+++ b/template.yml
@@ -1,0 +1,83 @@
+# Curvenote Init Template Configuration
+# This file customizes the questions asked during 'cn init'
+#
+# CUSTOMIZATION:
+# - Set 'enabled: false' to skip a question
+# - Change message, placeholder, hint text
+# - Set 'default: "value"' to provide a default answer (removes undefined)
+# - Set 'required: true' to make a question mandatory
+#
+# QUESTION TYPES:
+# - text: Single-line text input
+# - list: Comma-separated list (e.g., keywords, tags)
+# - people: Person list with ORCID/GitHub lookup (for authors, editors, contributors)
+#
+# USING THE 'PEOPLE' TYPE:
+# The 'people' type can be used for authors, editors, or contributors:
+#
+# - id: editors
+#   field: project.editors       # Use 'project.editors' or 'project.contributors'
+#   enabled: true
+#   type: people
+#   message: "Add editor(s):"
+#   placeholder: "ORCID, GitHub username, or comma-separated list"
+#   hint: "You can add multiple editors separated by commas"
+#   required: false
+#
+# ADDING CUSTOM QUESTIONS:
+# You can add custom text or list questions:
+#
+# - id: my_custom_field          # Unique identifier
+#   field: project.my_field      # Where to store in curvenote.yml
+#   enabled: true
+#   type: text                   # or 'list' for comma-separated
+#   message: "My custom question:"
+#   placeholder: "Example answer"
+#   hint: "Optional hint shown before the question"
+#   default: undefined           # Optional default value
+#   required: false
+#
+# Note: Custom fields will be added to your curvenote.yml under 'project'
+
+name: curvenote init
+version: 1
+questions:
+  - id: title
+    field: project.title
+    enabled: true
+    type: text
+    message: 'Project title:'
+    placeholder: e.g., My Research Project
+    required: false
+  - id: subtitle
+    field: project.subtitle
+    enabled: true
+    type: text
+    message: 'Subtitle:'
+    placeholder: A concise, single line description
+    hint: Keep it short - this appears as a tagline
+    required: false
+  - id: description
+    field: project.description
+    enabled: true
+    type: text
+    message: 'Description:'
+    placeholder: A longer description suitable for social media and listings
+    hint: Used for social media and article listings
+    required: false
+  - id: authors
+    field: project.authors
+    enabled: true
+    type: people
+    message: 'Add author(s):'
+    placeholder: ORCID, GitHub username, or comma-separated list
+    hint: You can add multiple authors separated by commas
+    required: false
+  - id: keywords
+    field: project.keywords
+    enabled: true
+    type: list
+    message: 'Keywords:'
+    placeholder: e.g., science, research, data analysis
+    hint: Help others discover your project
+    required: false


### PR DESCRIPTION
These changes start to convert the report more into a template. 

Firstly, we've created `base.yml` which we're now extending from `curvenote.yml`. This allows a whole bunch of standard settings and front matter to be packed into base.yaml, while reserving the `curvenote.yml` or things that the author should be concerned with. 

Secondly, we've run `curvenote init --write-template` and committed the `template.yml` here. The scope of what you can do with the `template.yml` is still small, but right now, you can edit and change the text within the prompts your authors will see when they run the template against this repo. i.e. `cn init --github https://github.com/antonrmolina/devnote-template`.

See docs on templates here: https://docs.curvenote.com/publish/creating-templates#part-2-generating-template-yml